### PR TITLE
Removed the spans for page actions.

### DIFF
--- a/app/utils/bsat/page_actions.rb
+++ b/app/utils/bsat/page_actions.rb
@@ -27,9 +27,7 @@ module Bsat
         concat(fa_icon(icon)) if icon.present?
         if label.present?
           concat(' ') if icon.present?
-          concat(
-            content_tag(:span, label)
-          )
+          concat(label)
         end
       end
     end
@@ -40,9 +38,7 @@ module Bsat
           concat(fa_icon(icon)) if icon.present?
           if label.present?
             concat(' ') if icon.present?
-            concat(
-              content_tag(:span, label)
-            )
+            concat(label)
           end
         end
       end


### PR DESCRIPTION
The spans around the label of a page action are not required.
